### PR TITLE
Removed an extra slash that Land reported in the youtube url embedding

### DIFF
--- a/class/Parse.php
+++ b/class/Parse.php
@@ -41,7 +41,7 @@ class BoardParse
     if($host != "youtube.com" && $host != "www.youtube.com") return $href[1];
     else
     {
-      $href = str_replace("watch?v=","/v/",$href[1]);
+      $href = str_replace("watch?v=","v/",$href[1]);
       return "<object width=\"425\" height=\"355\"><param name=\"movie\" value=\"$href\"></param><param name=\"wmode\" value=\"transparent\"></param><embed src=\"$href\" type=\"application/x-shockwave-flash\" wmode=\"transparent\" width=\"425\" height=\"355\"></embed></object>";
     }
   }


### PR DESCRIPTION
Land reported that an extra / was getting into the youtube URL embedding.  Looks like it's caused by the strreplace sticking "/v/" when there's already a "/" after the hostname.  I don't have a running copy of pgBoard locally so I couldn't test this fix.

...RL

resulting in URLs like this

http://youtube.com//v/...

removed the first "/" from the str replace.
