### PR TITLE
Cleaned up the Help link for Youtube embeds

### DIFF
--- a/lang/en.default.php
+++ b/lang/en.default.php
@@ -152,7 +152,7 @@ http://www.google.com/ <-- automatic link
 [code]like pre[/code]
 [sub]subscript[/sub]
 [sup]superscript[/sup]
-[youtube]http://www.youtube.com/watch?v=WAwLYJYsa0A[/youtube]
+[youtube]http://youtube.com/watch?v=WAwLYJYsa0A[/youtube] or [youtube]http://youtu.be/L8xXb-P4wZY[/youtube]
 [vimeo]http://vimeo.com/2467457[/vimeo]
 [quote]quote[/quote]
 </pre>


### PR DESCRIPTION
showed how you can embed both regular  youtube.com  and youtu.be shortened URLs now.
