### PR TITLE
Added in a parse method to create soundcloud embeds from a song url

### DIFF
--- a/class/Parse.php
+++ b/class/Parse.php
@@ -57,6 +57,32 @@ class BoardParse
     return $href[1];
   }
 
+  function soundcloud($href)
+  {
+    $host = parse_url($href[1]);
+    $host = isset($host['host']) ? $host['host'] : "";
+    
+    if($host == "soundcloud.com" || $host == "www.soundcloud.com" ) {
+
+      $height = 81;
+
+      // player embed URL accepts the encoded soundcloud page URL as the param
+      $href_encoded = rawurlencode($href[1]);
+      $embed_src = "http://player.soundcloud.com/player.swf?url=$href_encoded";
+
+      $embed  = "<object height=\"$height\" width=\"100%\">";
+      $embed .= "<param name=\"wmode\" value=\"opaque\">";
+      $embed .= "<param name=\"movie\" value=\"$embed_src\">";
+      $embed .= "<param name=\"allowscriptaccess\" value=\"always\">";
+      $embed .= "<embed allowscriptaccess=\"always\" height=\"$height\" src=\"$embed_src\" type=\"application/x-shockwave-flash\" width=\"100%\">";
+      $embed .= "</object>";
+
+      return $embed;
+    }
+
+    return $href[1];
+  }
+
   function vimeo($href)
   {
     $host = parse_url($href[1]);
@@ -100,12 +126,14 @@ class BoardParse
       $s = preg_replace("#\[img\](.*)\[\/img\]#Ui","<a href=\"$1\" class=\"link\" onclick=\"$(this).after('<img src=\\''+this.href+'\\' ondblclick=\\'window.open(this.src);return false\\'/>');$(this).remove();return false;\">IMAGE REMOVED CLICK TO VIEW</a>",$s);
       $s = preg_replace("#\[youtube\](.*)\[\/youtube\]#Ui","<a href=\"$1\" onclick=\"window.open(this.href); return false;\">YOUTUBE REMOVED CLICK TO VIEW</a>",$s);
       $s = preg_replace("#\[vimeo\](.*)\[\/vimeo\]#Ui","<a href=\"$1\" onclick=\"window.open(this.href); return false;\">VIMEO REMOVED CLICK TO VIEW</a>",$s);
+      $s = preg_replace("#\[soundcloud\](.*)\[\/soundcloud\]#Ui","<a href=\"$1\" onclick=\"window.open(this.href); return false;\">SOUNDCLOUD REMOVED CLICK TO VIEW</a>",$s);
     }
     else
     {
       $s = preg_replace("#\[img\](.*)\[\/img\]#Ui","<img src=\"$1\" ondblclick=\"window.open(this.src);\"/>",$s);
       $s = preg_replace_callback("#\[youtube\](.*)\[\/youtube\]#Ui",array(&$this,'youtube'),$s);
       $s = preg_replace_callback("#\[vimeo\](.*)\[\/vimeo\]#Ui",array(&$this,'vimeo'),$s);
+      $s = preg_replace_callback("#\[soundcloud\](.*)\[\/soundcloud\]#Ui",array(&$this,'soundcloud'),$s);
     }
 
     // start line break stuff

--- a/lang/en.default.php
+++ b/lang/en.default.php
@@ -152,6 +152,7 @@ http://www.google.com/ <-- automatic link
 [code]like pre[/code]
 [sub]subscript[/sub]
 [sup]superscript[/sup]
+[soundcloud]http://soundcloud.com/goingslowly/047-railroad-lullabye[/soundcloud]
 [youtube]http://youtube.com/watch?v=WAwLYJYsa0A[/youtube] or [youtube]http://youtu.be/L8xXb-P4wZY[/youtube]
 [vimeo]http://vimeo.com/2467457[/vimeo]
 [quote]quote[/quote]


### PR DESCRIPTION
soundcloud support was missing from the version of pgBoard that
was used for the intial commit to github.  This method and the
associated calls to it adds that support back in.

This uses the old style flash embed and song URL method of embedding
soundcloud's new embed snippets use a newer style flash player or
html 5 player. Both examples don't use the song url. At some point
we should try to update to the html 5 player so iOS users can see
them too
