### PR TITLE
Search form tweaks

### DIFF
--- a/class/Form.php
+++ b/class/Form.php
@@ -282,6 +282,11 @@ class Form
     print "  $('#$id').attr('notnull','$msg').addClass('validate_{$this->name}');\n";
   }
 
+  function set_focus($id)
+  {
+    print "  $('#$id').focus();";
+  }
+
   function footer_validate()
   {
     print "});\n";

--- a/module/message/.content/create.php
+++ b/module/message/.content/create.php
@@ -36,6 +36,7 @@ $Form->header_validate();
 $Form->add_notnull("message_members","Please enter at least one recipient.");
 $Form->add_notnull("subject","Please enter a subject.");
 $Form->add_notnull("body","Please enter a post body.");
+$Form->set_focus("_recipients");
 $Form->footer_validate();
 
 $Base->footer();

--- a/module/search/.content/main.php
+++ b/module/search/.content/main.php
@@ -37,6 +37,7 @@ $Form->footer();
 $Form->header_validate();
 $Form->add_notnull("search","Please enter a search term.");
 $Form->add_notnull("_type","Please choose what to search.");
+$Form->set_focus("search");
 $Form->footer_validate();
 
 if(!isset($res)) $Base->footer();

--- a/module/thread/.content/create.php
+++ b/module/thread/.content/create.php
@@ -19,6 +19,7 @@ $Form->footer();
 $Form->header_validate();
 $Form->add_notnull("subject","Please enter a subject.");
 $Form->add_notnull("body","Please enter a post body.");
+$Form->set_focus("subject");
 $Form->footer_validate();
 
 $Base->footer();


### PR DESCRIPTION
Cleaned up my changes from the last pull request to Form so that it uses the Form->values as expected to specify the selected option. Also changed  SELECTED to  selected="selected"

Also added a jquery helper to set_focus on a form field. Used it on the new message, new thread, and search pages to set focus to the most appropriate text box on page load.

(Closed out the last similiar pull request because I forgot to fetch the upstream changes and rebase this branch of top of them)
