### PR TITLE
Fix active list

### DIFF
--- a/module/main/get.php
+++ b/module/main/get.php
@@ -29,7 +29,8 @@ function status_get()
   $posting = array_keys($Core->posting_members());
   $lurking = array_keys($Core->lurking_members());
   $chatting = $Core->chatting_members();
-  $active = array_merge($active, $chatting);
+  $active += $chatting;
+  asort($active);
   $chatting = array_keys($chatting);
 
   $Base = new Base;


### PR DESCRIPTION
7989d3d's approach to adding chat users to the active list was
broken (array_merge() with numeric keys doesn't merge items
with the same key).  This probably works better.

As a sidenote, this increases CPU usage slightly as it requires
resorting (of mostly sorted items).  The alternative would be to
change the active members database query to include chatters
from the outset.
