### PR TITLE
Finish implementing ignore buffer

### DIFF
--- a/config.default.php
+++ b/config.default.php
@@ -13,6 +13,7 @@ define("MEMBER_REGEXP","^[a-z0-9_-]{3,15}$"); // regexp to define valid member n
 
 define("IGNORE_ENABLED",true); // if you disable this be sure to DELETE * FROM member_ignore
 define("IGNORE_PUBLIC",true); // set to false to make ignoring private
+define("IGNORE_BUFFER","1 year"); // how long from first post until ignore can be used (set false to disable)
 
 define("LIST_DEFAULT_LIMIT",100); // number of threads per page
 define("COLLAPSE_DEFAULT",25); // default value to collapse at


### PR DESCRIPTION
This feature makes it so that new users can not use the ignore feature (their first post must be at least a configurable time ago).

The implementation is not particularly elegant, but should serve to close sleekcode/pgBoard#17.
