### PR TITLE
Fix some JavaScript injection in the title

### DIFF
--- a/class/Base.php
+++ b/class/Base.php
@@ -65,7 +65,7 @@ class Base
     $_title_ = strip_tags($title);
     $Plugin = new BoardPlugin;
     $title = $Plugin->base_title($title);
-    $this->title = $title;
+    $this->title = strip_tags($title);
   }
   function subtitle($subtitle) { $this->subtitle = $subtitle; }
   function blocked($blocked) { $this->blocked = $blocked; }

--- a/module/message/get.php
+++ b/module/message/get.php
@@ -51,7 +51,7 @@ function view_get()
   $subject .= SPACE.ARROW_RIGHT.SPACE."<a href=\"/message/delete/".id()."/".md5(session_id())."/\">delete</a>";
   $subject .= "</span>";
   
-  $View->title($subject);
+  $View->title(htmlentities($subject));
 
   $DB->query("SELECT m.name,mm.deleted FROM message_member mm LEFT JOIN member m ON m.id=mm.member_id WHERE mm.message_id=$1",array(id()));
   $subtitle = "<strong>Participating:</strong> ";

--- a/module/thread/get.php
+++ b/module/thread/get.php
@@ -116,7 +116,7 @@ function view_get()
     $subtitle .= SPACE.ARROW_RIGHT.SPACE."<a href=\"/admin/togglesticky/".id()."/".md5(session_id())."/\">".($sticky ? "unsticky" :"sticky")."</a>";
     $subtitle .= SPACE.ARROW_RIGHT.SPACE."<a href=\"/admin/togglelocked/".id()."/".md5(session_id())."/\">".($locked ? "unlock" :"lock")."</a>";
   }
-  $View->title($View->subject(id()));
+  $View->title(htmlentities($View->subject(id())));
   $View->subtitle($subtitle);
 
   $View->header();


### PR DESCRIPTION
Specifically, this does two things.  Firstly, thread view and
message view now calls htmlentities() on the the title strings.
This seems like it's just correct.   There may be other places
where this should still be done more.

Secondly, Base now strips tags on the final version of the title
string as a "last resort".
