### PR TITLE
Fix incremental uncollapse for PMs

### DIFF
--- a/class/Query.php
+++ b/class/Query.php
@@ -288,7 +288,14 @@ class BoardQuery
     // set query conditionals
     $where = "WHERE mp.message_id=$message";
     $order = "ORDER BY mp.date_posted ASC";
-    $offset = $this->view_offset($offset);
+
+    // This is sort of a hack, but I'm not sure the normal case is actually
+    // useful or expected here (multiplying by some scale).
+    if (substr($offset,0,1) === '-')
+      $offset = 'OFFSET ' . strval(-intval($offset));
+    else
+      $offset = $this->view_offset($offset);
+
     $limit = $this->view_limit($limit);
     $ignore = "";
 


### PR DESCRIPTION
This is the same logic that was added to thread viewing, but wasn't done for PM viewing due to an oversight.  Result was that you couldn't incrementally uncollapse a PM.
