### PR TITLE
Rewrite of youtube embed code

### DIFF
--- a/lang/en.default.php
+++ b/lang/en.default.php
@@ -153,7 +153,8 @@ http://www.google.com/ <-- automatic link
 [sub]subscript[/sub]
 [sup]superscript[/sup]
 [soundcloud]http://soundcloud.com/goingslowly/047-railroad-lullabye[/soundcloud]
-[youtube]http://youtube.com/watch?v=WAwLYJYsa0A[/youtube] or [youtube]http://youtu.be/L8xXb-P4wZY[/youtube]
+[youtube]http://youtu.be/L8xXb-P4wZY[/youtube] or [youtube]http://www.youtube.com/watch?v=L8xXb-P4wZY[/youtube] (video)
+[youtube]https://www.youtube.com/playlist?list=PLf7Pime6sgNUom_fs9wktBPMo9IrEHJT-[/youtube] (playlist)
 [vimeo]http://vimeo.com/2467457[/vimeo]
 [quote]quote[/quote]
 </pre>


### PR DESCRIPTION
Followed the information in the latest youtube docs on embedding:
https://developers.google.com/youtube/player_parameters?hl=en

Wrote a set of regexps to parse the various formats of youtube
URLs from the location bar, the share button, and the embed src
under the share options, as well as some legacy URLs from the docs
site.

The regexps extract the video id and a string of all the other
URL parameters.

If the URL was for a single video the params are split out and
processed to remove autoplay and to convert the &t param into the
embed's &start version. They're then splatted back into a string.

If the URL was for a playlist from the location bar or share button
then it's split into a playlist id and params with autoplay stripped
out.

If the URL was a more advanced URL from the playlist embed src then
it's passed through because it's already the right format, just the
autoplay is removed if present. (playist embed url, user uploads
list, and videos matching a search query)

After all of the above the URL is then built at the end based on
those various sources and stuck into an <iframe> tag that has the
appropriate other settings to do the new embeds.  It defaults to
HTML5 player, but will fallback and handle older platforms and
mobile automatically.