### PR TITLE
use an index instead of a sequence scan

### DIFF
--- a/class/Query.php
+++ b/class/Query.php
@@ -341,10 +341,11 @@ class BoardQuery
             ON
               m.id = mp.message_id
             $where
-            AND
-              ".session('id')."
-            IN
-              (SELECT mm.member_id FROM message_member mm WHERE mm.message_id = mp.message_id)
+            AND EXISTS (
+              SELECT mm.member_id
+              FROM message_member mm
+              WHERE mm.message_id = mp.message_id AND mm.member_id = ".session('id')."
+            )
             $ignore
             $order
             $limit

--- a/doc/3-Indexes-FKeys-Triggers.sql
+++ b/doc/3-Indexes-FKeys-Triggers.sql
@@ -48,7 +48,7 @@ CREATE INDEX thread_post_member_ip ON thread_post(member_ip);
 CREATE INDEX thread_post_indexed_index ON thread_post(indexed);
 CREATE INDEX thread_post_edited_index ON thread_post(edited);
 CREATE INDEX thread_post_deleted_index ON thread_post(deleted);
-
+CREATE INDEX thread_post_thread_id_date_posted_index ON thread_post(thread_id, date_posted);
 ALTER TABLE thread_post ADD FOREIGN KEY (member_id) REFERENCES member(id);
 ALTER TABLE thread_post ADD FOREIGN KEY (thread_id) REFERENCES thread(id);
 

--- a/lib/sphinx/sphinx.conf.example
+++ b/lib/sphinx/sphinx.conf.example
@@ -2,25 +2,26 @@ searchd
 {
   read_timeout = 5
   max_children = 300
-  query_log = /path/to/query.log
-  log = /path/to/searchd.log
   max_matches = 10000000
+  query_log = /mnt/search/log/query.log
+  log  = /mnt/search/log/searchd.log
   seamless_rotate = 1
-  pid_file = /path/to/searchd.pid
+  pid_file = /mnt/search/searchd.pid
 }
 
 indexer
 {
-  mem_limit = 1024M 
+  mem_limit = 900M
 }
 
 source main
 {
   type = pgsql
-  sql_host = 
-  sql_user = imeyer
-  sql_pass = 
-  sql_db = bco
+  sql_host = <omitted>
+  sql_port = 5432
+  sql_user = board
+  sql_pass = <omitted>
+  sql_db = board
 }
 
 source thread : main
@@ -30,9 +31,11 @@ source thread : main
   sql_attr_timestamp = date_posted
 }
 
-source thread_post : main 
+source thread_post : main
 {
-  sql_query = SELECT id, body, member_id, date_posted FROM thread_post 
+  sql_range_step = 100000
+  sql_query_range = SELECT min(id),max(id) FROM thread_post WHERE length(body) < 64000
+  sql_query = SELECT id, body, member_id, date_posted FROM thread_post WHERE length(body) < 64000 AND id BETWEEN $start AND $end
   sql_attr_uint = member_id
   sql_attr_timestamp = date_posted
 }
@@ -40,7 +43,7 @@ source thread_post : main
 index thread
 {
   source = thread
-  path = /path/to/thread/thread
+  path = /mnt/search/thread/thread
   morphology = stem_en
   charset_type = utf-8
 }
@@ -48,7 +51,7 @@ index thread
 index thread_post
 {
   source = thread_post
-  path = /path/to/thread_post/thread_post
+  path = /mnt/search/thread_post/thread_post
   morphology = stem_en
   charset_type = utf-8
 }


### PR DESCRIPTION
this cuts query execution for some messages from 2000ms to 2ms