### PR TITLE
Replace removed eregi calls with preg_match.

### DIFF
--- a/module/member/post.php
+++ b/module/member/post.php
@@ -28,9 +28,9 @@ function create_post()
   $output = "";
   if($DB->check("SELECT true FROM member WHERE LOWER(name)=$1",array(strtolower(post('account'))))) $output .= ERROR_MEMBER_NAME_INUSE."<br/>";
 
-  if(!eregi(MEMBER_REGEXP,post('account'))) $output .= ERROR_MEMBER_NAME."<br/>";
+  if(!preg_match(MEMBER_REGEXP,post('account'))) $output .= ERROR_MEMBER_NAME."<br/>";
 
-  if(eregi("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$",post('email_signup')))
+  if(preg_match("^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$",post('email_signup')))
   {
     if(post('email_signup') != post('email_confirm')) $output .= ERROR_MEMBER_EMAIL_NOMATCH."<br/>\n";
   }


### PR DESCRIPTION
This PR replaces calls to `eregi` in favor of `preg_match`.  `eregi` was deprecated in PHP 5.3 and removed altogether in PHP 7.0. 

Merging this change should be the last updated required to make the board's PHP code fully compatible with PHP 8.2.