### PR TITLE
Set max-width on images for all viewport sizes.

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -28,7 +28,7 @@ a:hover { text-decoration: underline; }
 .clear { clear: both; }
 .blink { text-decoration: blink; }
 .link,.lurker a { text-decoration: underline !important; }
-img { cursor: pointer; }
+img { cursor: pointer; max-width: 100%; }
 h1,h2,h3,h4,h5 { font-weight: bold; }
 h1 { font-size: 2.0em; }
 h2 { font-size: 1.8em; }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -31,20 +31,18 @@
 }
 
 @media only screen and (max-width: 930px){
-	
+
 	html body {
 		margin: 0;
 		padding: 0px 0px;
 	}
-			
-	img { max-width: 100%; }
 
 	#content {
 		display: block;
 		width: 100% !important;
 		min-width: 320px !important;
 	}
-		
+
 	#content .pad {
 		margin: 0;
 		padding: 0;


### PR DESCRIPTION
Some time ago, we set the maximum width for images to 100% on mobile styles, but not for desktop styles. This PR corrects this problem by moving the `max-width` declaration to the base image styling file. 

## Before
<img width="1974" alt="image" src="https://github.com/pgBoard/pgBoard/assets/1407326/5223361c-34bd-4924-9b68-6dea79629edc">

## After 
<img width="1449" alt="image" src="https://github.com/pgBoard/pgBoard/assets/1407326/bad044ed-1540-48fb-a524-b72690eb878d">

And it still works on mobile:
<img width="713" alt="image" src="https://github.com/pgBoard/pgBoard/assets/1407326/230463e1-7b1e-4762-b528-44870733cd85">
